### PR TITLE
Prefill hostname with archipelago.gg to match other games 

### DIFF
--- a/src/archipelago.js
+++ b/src/archipelago.js
@@ -13,7 +13,7 @@ client.messages.on("message", (content) => {
 
 var $ap_options_window = $Window({ title: "Archipelago Connection Options", minimizeButton: false, maximizeButton: false, closeButton: false })
 	.addClass("maximized").addClass("focused").css({ left: 0, top: 0, width: "100vw", height: "100vh" });
-$ap_options_window.$content.append('<p><label>Host: <input name="aphost"></label></p><p><label>Port: <input name="apport"></label></p><p><label>Slot name: <input name="apslot"></label></p><p><label>Password: <input name="appass"></label></p>');
+$ap_options_window.$content.append('<p><label>Host: <input name="aphost" value="archipelago.gg"></label></p><p><label>Port: <input name="apport" placeholder="34567"></label></p><p><label>Slot name: <input name="apslot"></label></p><p><label>Password: <input name="appass"></label></p>');
 $("<button>Connect!</button>").on("click", function () {
 	client.login($("[name=aphost]").val() + ":" + $("[name=apport]").val(), $("[name=apslot]").val(), "Paint", { "password": $("[name=appass]").val(), })
 		.then(function (e) {

--- a/src/archipelago.js
+++ b/src/archipelago.js
@@ -13,7 +13,7 @@ client.messages.on("message", (content) => {
 
 var $ap_options_window = $Window({ title: "Archipelago Connection Options", minimizeButton: false, maximizeButton: false, closeButton: false })
 	.addClass("maximized").addClass("focused").css({ left: 0, top: 0, width: "100vw", height: "100vh" });
-$ap_options_window.$content.append('<p><label>Host: <input name="aphost" value="archipelago.gg"></label></p><p><label>Port: <input name="apport" placeholder="34567"></label></p><p><label>Slot name: <input name="apslot"></label></p><p><label>Password: <input name="appass"></label></p>');
+$ap_options_window.$content.append('<p><label>Host: <input name="aphost" value="archipelago.gg"></label></p><p><label>Port: <input name="apport" placeholder="38281"></label></p><p><label>Slot name: <input name="apslot"></label></p><p><label>Password: <input name="appass"></label></p>');
 $("<button>Connect!</button>").on("click", function () {
 	client.login($("[name=aphost]").val() + ":" + $("[name=apport]").val(), $("[name=apslot]").val(), "Paint", { "password": $("[name=appass]").val(), })
 		.then(function (e) {


### PR DESCRIPTION
Other AP games tend to prefill the host field with the official archipelago.gg website while also having a placeholder for the port.

![image](https://github.com/user-attachments/assets/1373c0ac-bbce-4d06-aa69-8c6727ea26df)
