### PR TITLE
Export / import archipelago session

### DIFF
--- a/help/archipelago.html
+++ b/help/archipelago.html
@@ -29,6 +29,10 @@
 			appear the same neutral gray as the area around the canvases.</li>
 		<li>The <b>Pick Color</b> tool, once unlocked, can be used on the target image as well as on the main canvas.
 		</li>
+		<li>Progress is automatically saved in your browser when you exit. If you want to back up your progress or
+			transfer it to another computer, you can use <b>File->Export Session</b> to save your current session as
+			a file and <b>File->Import Session</b> to restore it.
+		</li>
 	</ul>
 </body>
 

--- a/src/menus.js
+++ b/src/menus.js
@@ -144,6 +144,17 @@ const menus = {
 		},
 		MENU_DIVIDER,
 		{
+			label: localize("Export Session..."),
+			action: () => { window.export_local_session(); },
+			description: localize("Exports the current local session to a file."),
+		},
+		{
+			label: localize("Import Session..."),
+			action: () => { window.import_local_session(); },
+			description: localize("Imports a session file and loads it."),
+    },
+		MENU_DIVIDER,
+		{
 			label: localize("Print Pre&view"),
 			speech_recognition: [
 				"preview print", "print preview", "show print preview", "show preview of print",

--- a/src/menus.js
+++ b/src/menus.js
@@ -152,7 +152,7 @@ const menus = {
 			label: localize("Import Session..."),
 			action: () => { window.import_local_session(); },
 			description: localize("Imports a session file and loads it."),
-    },
+		},
 		MENU_DIVIDER,
 		{
 			label: localize("Print Pre&view"),

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -135,7 +135,7 @@ class LocalSession {
 				return;
 			}
 			log(`Saving image to storage: ${ls_key}`);
-			localStore.set(ls_key, this.collect_session_data()),
+			localStore.set(ls_key, this.collect_session_data(),
 				(err) => {
 					if (err) {
 						// @ts-ignore (quotaExceeded is added by storage.js)
@@ -147,7 +147,7 @@ class LocalSession {
 							// @TODO: show warning with "Don't tell me again" type option
 						}
 					}
-				});
+				})
 		};
 		this.save_image_to_storage_soon = debounce(this.save_image_to_storage_immediately, 100);
 		localStore.get(ls_key, (err, data) => {

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -109,6 +109,23 @@ function handle_data_loss() {
 	return save_paused;
 }
 
+function save_image_to_storage(key, value) {
+	log(`Saving image to storage: ${key}`);
+	localStore.set(key, value,
+		(err) => {
+			if (err) {
+				// @ts-ignore (quotaExceeded is added by storage.js)
+				if (err.quotaExceeded) {
+					storage_quota_exceeded();
+				} else {
+					// e.g. localStorage is disabled
+					// (or there's some other error?)
+					// @TODO: show warning with "Don't tell me again" type option
+				}
+			}
+		})
+}
+
 class LocalSession {
 	constructor(session_id) {
 		this.id = session_id;
@@ -134,20 +151,7 @@ class LocalSession {
 			if (save_paused) {
 				return;
 			}
-			log(`Saving image to storage: ${ls_key}`);
-			localStore.set(ls_key, this.collect_session_data(),
-				(err) => {
-					if (err) {
-						// @ts-ignore (quotaExceeded is added by storage.js)
-						if (err.quotaExceeded) {
-							storage_quota_exceeded();
-						} else {
-							// e.g. localStorage is disabled
-							// (or there's some other error?)
-							// @TODO: show warning with "Don't tell me again" type option
-						}
-					}
-				})
+			save_image_to_storage(ls_key, this.collect_session_data());
 		};
 		this.save_image_to_storage_soon = debounce(this.save_image_to_storage_immediately, 100);
 		localStore.get(ls_key, (err, data) => {
@@ -1168,19 +1172,7 @@ async function import_local_session() {
 	end_current_session();
 
 	try {
-		localStore.set(`image#${payload.session_id}`, payload.data,
-			(err) => {
-				if (err) {
-					// @ts-ignore (quotaExceeded is added by storage.js)
-					if (err.quotaExceeded) {
-						storage_quota_exceeded();
-					} else {
-						// e.g. localStorage is disabled
-						// (or there's some other error?)
-						// @TODO: show warning with "Don't tell me again" type option
-					}
-				}
-			});
+		save_image_to_storage(`image#${payload.session_id}`, payload.data);
 	} catch (error) {
 		show_error_message(localize("Failed to write session data to local storage."), error);
 		return;

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -115,14 +115,8 @@ class LocalSession {
 		this.palette = palette;
 		const ls_key = `image#${session_id}`;
 		log(`Local storage key: ${ls_key}`);
-		// save image to storage
-		this.save_image_to_storage_immediately = () => {
-			const save_paused = handle_data_loss();
-			if (save_paused) {
-				return;
-			}
-			log(`Saving image to storage: ${ls_key}`);
-			localStore.set(ls_key, JSON.stringify({
+		this.collect_session_data = () => {
+			return JSON.stringify({
 				canvas: main_canvas.toDataURL("image/png"),
 				goal: goal_canvas.toDataURL("image/png"),
 				connection_info: {
@@ -132,18 +126,28 @@ class LocalSession {
 					"pass": $("[name=appass]").val()
 				},
 				colors: palette
-			}), (err) => {
-				if (err) {
-					// @ts-ignore (quotaExceeded is added by storage.js)
-					if (err.quotaExceeded) {
-						storage_quota_exceeded();
-					} else {
-						// e.g. localStorage is disabled
-						// (or there's some other error?)
-						// @TODO: show warning with "Don't tell me again" type option
-					}
-				}
 			});
+		};
+		// save image to storage
+		this.save_image_to_storage_immediately = () => {
+			const save_paused = handle_data_loss();
+			if (save_paused) {
+				return;
+			}
+			log(`Saving image to storage: ${ls_key}`);
+			localStore.set(ls_key, this.collect_session_data()),
+				(err) => {
+					if (err) {
+						// @ts-ignore (quotaExceeded is added by storage.js)
+						if (err.quotaExceeded) {
+							storage_quota_exceeded();
+						} else {
+							// e.g. localStorage is disabled
+							// (or there's some other error?)
+							// @TODO: show warning with "Don't tell me again" type option
+						}
+					}
+				});
 		};
 		this.save_image_to_storage_soon = debounce(this.save_image_to_storage_immediately, 100);
 		localStore.get(ls_key, (err, data) => {
@@ -1092,6 +1096,104 @@ const new_local_session = () => {
 	change_url_param("local", generate_session_id());
 };
 
+const session_export_format = {
+	formatID: "application/vnd.jspaint.session",
+	mimeType: "application/json",
+	name: localize("JS Paint Session (*.appaint)"),
+	nameWithExtensions: localize("JS Paint Session (*.appaint)"),
+	extensions: ["appaint"],
+};
+
+async function export_local_session() {
+	if (!current_session || !(current_session instanceof LocalSession)) {
+		show_error_message(localize("No local session is available to export."));
+		return;
+	}
+	const session_id = current_session.id;
+
+	// Package local session data
+	let payload = {
+		version: 1, // Allows us to make changes to the formatting later without breaking compatibility
+		session_id,
+		data: current_session.collect_session_data()
+	}
+
+	const blob = new Blob([JSON.stringify(payload)], { type: "application/json" });
+
+	await systemHooks.showSaveFileDialog({
+		dialogTitle: localize("Export Session"),
+		formats: [session_export_format],
+		defaultFileName: `${session_id}`,
+		getBlob: () => Promise.resolve(blob),
+	});
+}
+
+async function import_local_session() {
+	const { file } = await systemHooks.showOpenFileDialog({
+		formats: [session_export_format],
+	});
+	if (!file) {
+		return;
+	}
+
+	let payload;
+	try {
+		payload = JSON.parse(await file.text());
+	} catch (_error) {
+		show_error_message(localize("Invalid session file format."));
+		return;
+	}
+
+	if (payload.version !== 1) {
+		show_error_message(localize("Invalid session file version. This file may have been created by a newer version of the software."));
+		return;
+	}
+
+	if (!payload || !payload.session_id || typeof payload.session_id !== "string" || !payload.data) {
+		show_error_message(localize(`Invalid session file. ${JSON.stringify(payload)}`));
+		return;
+	}
+	try {
+		// We want to retain the existing connection info
+		let payload_data = JSON.parse(payload.data);
+		let existing_connection_info = JSON.parse(current_session.collect_session_data()).connection_info;
+		payload_data.connection_info = existing_connection_info;
+		payload.data = JSON.stringify(payload_data);
+	}
+	catch (e) {
+		show_error_message(localize(`Error when retaining connection info: ${e.message}`), e);
+	}
+
+	// Ends the session to both ensure we don't get conflicting sets and to ensure that we update the session even if the session ID is the same
+	end_current_session();
+
+	try {
+		localStore.set(`image#${payload.session_id}`, payload.data,
+			(err) => {
+				if (err) {
+					// @ts-ignore (quotaExceeded is added by storage.js)
+					if (err.quotaExceeded) {
+						storage_quota_exceeded();
+					} else {
+						// e.g. localStorage is disabled
+						// (or there's some other error?)
+						// @TODO: show warning with "Don't tell me again" type option
+					}
+				}
+			});
+	} catch (error) {
+		show_error_message(localize("Failed to write session data to local storage."), error);
+		return;
+	}
+
+	// Switch to the imported session
+	change_url_param("local", payload.session_id);
+	// @TODO: Updating palette does not work while in the same window session, this was an existing bug
+	current_session.palette = payload.data.palette;
+}
+
+window.export_local_session = export_local_session;
+window.import_local_session = import_local_session;
 // @TODO: Session GUI
 // @TODO: Indicate when the session ID is invalid
 // @TODO: Indicate when the session switches

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -176,6 +176,7 @@ class LocalSession {
 						$("[name=ap" + i + "]").val(json_data.connection_info[i]);
 					}
 					this.palette = json_data.colors;
+					palette = this.palette;
 				}
 				catch (_) {
 					load_image_from_uri(data).then((info) => {
@@ -1173,6 +1174,7 @@ async function import_local_session() {
 
 	try {
 		save_image_to_storage(`image#${payload.session_id}`, payload.data);
+		$colorbox.rebuild_palette(JSON.parse(payload.data).colors);
 	} catch (error) {
 		show_error_message(localize("Failed to write session data to local storage."), error);
 		return;
@@ -1180,8 +1182,6 @@ async function import_local_session() {
 
 	// Switch to the imported session
 	change_url_param("local", payload.session_id);
-	// @TODO: Updating palette does not work while in the same window session, this was an existing bug
-	current_session.palette = payload.data.palette;
 }
 
 window.export_local_session = export_local_session;


### PR DESCRIPTION
### Overview
My friend had an issue with their browser and lost progress, which this aims to mitigate.

This allow someone to save their game state to either save progress or to migrate to another computer / browser.

It adds `File->Export Session` and `File->Import Session`, allowing you to save and restore a `<filename>.appaint` file.

You can try out the changes here: https://robertecurtin.github.io/jspaint/ 

### Key changes
- [x] Updated in-app documentation
- [x] Added `File->Export Session`
- [x] Added `File->Import Session`

### Testing
- [x] Imported a session with a different URL, observed that the URL was updated
- Imported a session with a different goal / target image, observed that the goal and target image were updated
  - [x] With a different image ID
  - [x] With the same image ID
- [x] Saved a file with a name not matching the `#image` name, observed that it loaded to the relevant image
- [x] Opened a session with image larger than the canvas space, observed that the image was cut off and additional checks were not awarded (had to draw a line before it refreshed)
- [x] Opened a session with image smaller than the canvas space, observed that the image filled in as much as it could and left the rest of the canvas untouched 
  - This is a little strange, but probably desirable
- [x] Confirmed that cancelling the dialog results in no change to the canvas and returns to the app

### Issues
Currently, palette loading doesn't work. I tested this with the existing Manage Storage and saw the same issue there, so I'll need to do some more digging before I can get that to work. That may be best as a future PR.

### Questions for Mario
- Does the file format `.appaint` make sense? I don't know if there's a standard convention